### PR TITLE
fix: make it produce the same results as Neptune

### DIFF
--- a/bls12_381/element.go
+++ b/bls12_381/element.go
@@ -59,6 +59,12 @@ func Modulus() *big.Int {
 	return new(big.Int).Set(&_modulus)
 }
 
+// Returns true if the big integer represents a valid field element, i.e. it's smaller
+// than the modulus.
+func IsValid(z *big.Int) bool {
+	return z.Cmp(Modulus()) == -1
+}
+
 // q (modulus)
 var qElement = Element{
 	18446744069414584321,

--- a/poseidon.go
+++ b/poseidon.go
@@ -39,9 +39,9 @@ var PoseidonExp = new(big.Int).SetUint64(5)
 func Hash(input []*big.Int, pdsContants *PoseidonConst, hash HashMode) (*big.Int, error) {
 	state := bigToElement(input)
 
-	//state[0] = 0,state[1:width] = input
-	zero := new(ff.Element).SetZero()
-	state = append([]*ff.Element{zero}, state...)
+	// Neptune (a Rust implementation of Poseidon) is using domain tag 0x3 by default.
+	domain_tag := new(ff.Element).SetString("3")
+	state = append([]*ff.Element{domain_tag}, state...)
 
 	//pdsContants, err := genPoseidonConstants(t)
 	//if err != nil {

--- a/poseidon_test.go
+++ b/poseidon_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	ff "github.com/triplewz/poseidon/bls12_381"
+	"math/big"
 	"os"
 	"testing"
 )
@@ -113,6 +114,14 @@ func TestPoseidonHash(t *testing.T) {
 		assert.Equal(t, h1, h2)
 		assert.Equal(t, h1, h3)
 	}
+}
+
+func TestPoseidonHashFixed(t *testing.T) {
+	cons, _ := GenPoseidonConstants(3)
+	input := []*big.Int{big.NewInt(0), big.NewInt(0)}
+	hash, _ := Hash(input, cons, OptimizedStatic)
+	expected, _ := new(big.Int).SetString("48fe0b1331196f6cdb33a7c6e5af61b76fd388e1ef1d3d418be5147f0e4613d4", 16)
+	assert.Equal(t, hash, expected)
 }
 
 func benchmarkStatic(b *testing.B, str []string) {


### PR DESCRIPTION
The README refers to Neptune, a Rust implementation of Poseidon. With these changes the same hash is produced in both implementations.